### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,6 @@
     "league/url": "~3.3.5",
     "concretecms/doctrine-xml": "^1.2.0",
     "ocramius/proxy-manager": "^2.0",
-    "paragonie/random_compat": "^2.0",
     "league/flysystem-cached-adapter": "~1.0.3",
     "lcobucci/jwt": "3.4.6|^4.1",
     "league/csv": "^9.7.1",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^2.0`, but also `php: ^7.3||^8.0`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?